### PR TITLE
Use the ConnectionString from Azure

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,11 +19,20 @@ class MulterAzureStorage {
         this.containerCreated = false
         this.containerError = false
 
+        let azureUseConnectionString
+
         let missingParameters = []
-        if (!opts.azureStorageConnectionString) missingParameters.push("azureStorageConnectionString")
-        if (!opts.azureStorageAccessKey) missingParameters.push("azureStorageAccessKey")
-        if (!opts.azureStorageAccount) missingParameters.push("azureStorageAccount")
+
+        if (!opts.azureStorageConnectionString) {
+            azureUseConnectionString = false;
+            if (!opts.azureStorageAccessKey) missingParameters.push("azureStorageAccessKey")
+            if (!opts.azureStorageAccount) missingParameters.push("azureStorageAccount")
+        } else {
+            azureUseConnectionString = true;
+        }
+
         if (!opts.containerName) missingParameters.push("containerName")
+
 
         if (missingParameters.length > 0) {
           throw new Error('Missing required parameter' + (missingParameters.length > 1 ? 's' : '') + ' from the options of MulterAzureStorage: ' + missingParameters.join(', '))
@@ -33,10 +42,13 @@ class MulterAzureStorage {
 
         this.fileName = opts.fileName
 
-        this.blobService = azure.createBlobService(
-            opts.azureStorageAccount,
-            opts.azureStorageAccessKey,
-            opts.azureStorageConnectionString)
+        if(azureUseConnectionString){
+            this.blobService = azure.createBlobService(opts.azureStorageConnectionString)
+        } else {
+            this.blobService = azure.createBlobService(
+                opts.azureStorageAccount,
+                opts.azureStorageAccessKey)
+        }
 
         let security = opts.containerSecurity || defaultSecurity
 


### PR DESCRIPTION
If you get the ConnectionString from the Azure-Portal, it already contains all the information `azure-node` needs to connect to Azure Blob Storage. Therefore, `azureStorageAccessKey` and `azureStorageAccount` aren't needed if the connectionString is given.

This shouldn't break any old code which provides all three options, it will just ignore `azureStorageAccessKey` and `azureStorageAccount`. However it could break if the given ConnectionString is not correct or was used for other purposes such as defining the host, but i'm not sure which use that has since AzureStorageAccounts do not include their region in their url.