### PR TITLE
Update to azure-storage 2.8.3 to fix vulnerabilities found by npm audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "azure storage"
   ],
   "dependencies": {
-    "azure-storage": "^1.3.1",
+    "azure-storage": "^2.8.3",
     "node-uuid": "^1.4.7"
   },
   "engines": {


### PR DESCRIPTION
Steps:

- install npm 6+
- run npm audit

> `found 5 moderate severity vulnerabilities in 105 scanned packages`

This PR updates azure-storage to 2.8.3.

When you run `npm audit` you now get:

> found 0 vulnerabilities in 82 scanned packages.

We've been using 2.8.3 for a little while now, and haven't noticed any issue with the library.